### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -495,7 +495,9 @@ DDEV comes ready to work with any PHP project, and has deeper support for severa
 
     If you have an existing Craft CMS DDEV project, you'll need to change the `type:` to `craftcms` in your project's `.ddev/config.yaml` and then do `ddev restart` to be able to use the `ddev craft` command.
 
-    If you have Craft CMS installed in a sub-directory in your project, you can add a `CRAFT_CMD_ROOT` environment variable to your `.env` file to specify a path relative to your project root where Craft CMS is installed. This defaults to `./`, the project root directory.
+    If you have Craft CMS installed in a sub-directory of your project, in order for `ddev craft` to work, you will need to change the location of the `craft` executable by providing the `CRAFT_CMD_ROOT` environment variable to the web container in your project. For example, if your directory structure is `my-craft-project/app`, where CraftCMS is installed in `app`, then you would apply `ddev config --web-environment-add=CRAFT_CMD_ROOT=./app`. `CRAFT_CMD_ROOT` defaults to `./`, the project root directory. Run `ddev restart` after applying this change.
+    
+    For more information about how to provide custom environment variables to your containers, read [Providing Custom Environment Variables to a Container](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-environment-variables-to-a-container).
 
 === "Shopware 6"
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
The original documentation related to changing where the `craft` executable is located in CraftCMS projects was slightly misleading as it implied you could make this change via and `.env` file.

## How this PR Solves The Problem:
This PR updates the docs to show how to provide this variable via DDEV's documented methods for providing environment variables to containers.

## Manual Testing Instructions:
Set up a CraftCMS project where the Craft application lives in a subdirectory. Follow the docs to set the location of the `craft` executable. Restart your project and test that `ddev craft` works.

## Related Issue Link(s):
https://github.com/drud/ddev/issues/4309

Closes #4309